### PR TITLE
Instala csvkit con pip en lugar de apt-get

### DIFF
--- a/_Dockerfile.body
+++ b/_Dockerfile.body
@@ -10,7 +10,6 @@ ENV TZ=US/Pacific
 # Instala paquetes en el sistema operativo
 RUN apt-get update && apt-get install --yes --no-install-recommends apt-utils
 RUN apt-get update && apt-get install --yes --no-install-recommends \
-    csvkit \
     curl \
     docker.io \
     gettext-base \
@@ -37,7 +36,9 @@ RUN git clone https://github.com/IslasGECI/queries.git && \
     rm --recursive queries
 
 # Instala descarga_datos
-RUN pip install git+https://github.com/IslasGECI/descarga_datos.git@v0.1.0-beta
+RUN pip install \
+    csvkit \
+    git+https://github.com/IslasGECI/descarga_datos.git@v0.1.0-beta
 
 # Instala paquetes de R
 RUN R -e "install.packages('stringi', repo='http://cran.rstudio.com/')" && \

--- a/_Dockerfile.body
+++ b/_Dockerfile.body
@@ -27,6 +27,11 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
         && \
     apt clean
 
+# Instala descarga_datos
+RUN pip install \
+    csvkit \
+    git+https://github.com/IslasGECI/descarga_datos.git@v0.1.0-beta
+
 # Instala repo de queries
 RUN git clone https://github.com/IslasGECI/queries.git && \
     cd queries && \
@@ -34,11 +39,6 @@ RUN git clone https://github.com/IslasGECI/queries.git && \
     make tests && \
     cd .. && \
     rm --recursive queries
-
-# Instala descarga_datos
-RUN pip install \
-    csvkit \
-    git+https://github.com/IslasGECI/descarga_datos.git@v0.1.0-beta
 
 # Instala paquetes de R
 RUN R -e "install.packages('stringi', repo='http://cran.rstudio.com/')" && \


### PR DESCRIPTION
por que la versión instalada con apt-get causa un problema al leer los datos en Excel de gatos en Isla Guadalupe